### PR TITLE
#2 prevent subscription error handling once server close has begun

### DIFF
--- a/src/microservice/gcloud-pub-sub.server.spec.ts
+++ b/src/microservice/gcloud-pub-sub.server.spec.ts
@@ -46,10 +46,18 @@ describe('GCloudPubSubServer', () => {
 		it('Initializes the PubSub client and subscription objects', () => {
 			const mockCallback = jest.fn()
 			server.listen(mockCallback)
+			expect(server.isClosing).toStrictEqual(false)
 			expect(server.client).not.toBe(null)
 			expect(server.subscriptions.length).not.toBe(0)
 			expect(mockCallback).toHaveBeenCalled()
 			expect(mockEventHandler).toHaveBeenCalledTimes(9)
+		})
+
+		it('Resets isClosing state', () => {
+			const mockCallback = jest.fn()
+			server.isClosing = true
+			server.listen(mockCallback)
+			expect(server.isClosing).toStrictEqual(false)
 		})
 	})
 

--- a/src/microservice/gcloud-pub-sub.server.ts
+++ b/src/microservice/gcloud-pub-sub.server.ts
@@ -16,6 +16,7 @@ export class GCloudPubSubServer extends Server implements CustomTransportStrateg
 	}
 
 	public listen(callback: () => void) {
+		this.isClosing = false
 		this.client = new PubSub(this.options.authOptions)
 		this.options.subscriptionIds.forEach(subcriptionName => {
 			const subscription = this.client.subscription(subcriptionName)


### PR DESCRIPTION
This PR adds a flag to `GCloudPubSubServer `, usually false, flipped to true when `.close()` is first called, so that we do not continue handling errors in handleError once close has been called.

Described in Issue #2.