### PR TITLE
HS-332: Adding subscriber options support to microservice

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ async function bootstrap() {
 	const GCloudPubSubServerOptions = {
 		authOptions: {/* Authentication options */}),
 		subscriptionIds: ['subscription-name'],
+		subscriberOptions: {/* https://googleapis.dev/nodejs/pubsub/latest/global.html#SubscriberOptions */}
 	}
 
 	app.connectMicroservice({

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-	"name": "nodejs-gcloud-pubsub-module",
-	"version": "0.0.2",
+	"name": "@ecobee/nodejs-gcloud-pubsub-module",
+	"version": "0.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -212,14 +212,12 @@
 			}
 		},
 		"@google-cloud/paginator": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-1.0.2.tgz",
-			"integrity": "sha512-mUqsRAJ/OT/Zo/Qh2v+kEeWsEgKZtK4vs2skSiVeudPLwjLSVng+fYZYtLK4kx05OSnm16MqurcPqW14g1/TgQ==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-2.0.1.tgz",
+			"integrity": "sha512-HZ6UTGY/gHGNriD7OCikYWL/Eu0sTEur2qqse2w6OVsz+57se3nTkqH14JIPxtf0vlEJ8IJN5w3BdZ22pjCB8g==",
 			"requires": {
 				"arrify": "^2.0.0",
-				"extend": "^3.0.1",
-				"split-array-stream": "^2.0.0",
-				"stream-events": "^1.0.4"
+				"extend": "^3.0.2"
 			}
 		},
 		"@google-cloud/precise-date": {
@@ -238,23 +236,22 @@
 			"integrity": "sha512-7WfV4R/3YV5T30WRZW0lqmvZy9hE2/p9MvpI34WuKa2Wz62mLu5XplGTFEMK6uTbJCLWUxTcZ4J4IyClKucE5g=="
 		},
 		"@google-cloud/pubsub": {
-			"version": "0.30.1",
-			"resolved": "https://registry.npmjs.org/@google-cloud/pubsub/-/pubsub-0.30.1.tgz",
-			"integrity": "sha512-xMNylRrAi84jFuPfuzJELMJg0zz5p0M1q3ACVaPF8Fst2sNKaNr5WBMqg0vNP/zFtsn17wxcNfcZSP6DiI/Q0Q==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@google-cloud/pubsub/-/pubsub-1.1.5.tgz",
+			"integrity": "sha512-gFWYWkTVRgR0qPhQzUoKXu9m21P6zcJ9ORWMX+LcHqJuc1NNBpn7MTMoQTZQIof6GPUo0bTMzvkyTrq9wVTS8A==",
 			"requires": {
-				"@google-cloud/paginator": "^1.0.0",
+				"@google-cloud/paginator": "^2.0.0",
 				"@google-cloud/precise-date": "^1.0.0",
 				"@google-cloud/projectify": "^1.0.0",
 				"@google-cloud/promisify": "^1.0.0",
-				"@grpc/grpc-js": "^0.4.3",
-				"@sindresorhus/is": "^0.17.1",
+				"@sindresorhus/is": "^1.0.0",
 				"@types/duplexify": "^3.6.0",
 				"@types/long": "^4.0.0",
 				"arrify": "^2.0.0",
 				"async-each": "^1.0.1",
 				"extend": "^3.0.2",
-				"google-auth-library": "^3.0.0",
-				"google-gax": "^1.0.0",
+				"google-auth-library": "^5.5.0",
+				"google-gax": "^1.7.5",
 				"is-stream-ended": "^0.1.4",
 				"lodash.snakecase": "^4.1.1",
 				"p-defer": "^3.0.0",
@@ -262,17 +259,17 @@
 			}
 		},
 		"@grpc/grpc-js": {
-			"version": "0.4.3",
-			"resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-0.4.3.tgz",
-			"integrity": "sha512-09qiFMBh90YZ4P5RFzvpSUvBi9DmftvTaP+mmmTzigps0It5YxuwQNqDAo9pI7SWom/6A5ybxv2CUGNk86+FCg==",
+			"version": "0.6.9",
+			"resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-0.6.9.tgz",
+			"integrity": "sha512-r1nDOEEiYmAsVYBaS4DPPqdwPOXPw7YhVOnnpPdWhlNtKbYzPash6DqWTTza9gBiYMA5d2Wiq6HzrPqsRaP4yA==",
 			"requires": {
-				"semver": "^6.0.0"
+				"semver": "^6.2.0"
 			}
 		},
 		"@grpc/proto-loader": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.5.1.tgz",
-			"integrity": "sha512-3y0FhacYAwWvyXshH18eDkUI40wT/uGio7MAegzY8lO5+wVsc19+1A7T0pPptae4kl7bdITL+0cHpnAPmryBjQ==",
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.5.2.tgz",
+			"integrity": "sha512-eBKD/FPxQoY1x6QONW2nBd54QUEyzcFP9FenujmoeDPy1rutVSHki1s/wR68F6O1QfCNDx+ayBH1O2CVNMzyyw==",
 			"requires": {
 				"lodash.camelcase": "^4.3.0",
 				"protobufjs": "^6.8.6"
@@ -555,9 +552,9 @@
 			"integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
 		},
 		"@sindresorhus/is": {
-			"version": "0.17.1",
-			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.17.1.tgz",
-			"integrity": "sha512-kg/maAZD2Z2AHDFp7cY/ACokjUL0e7MaupTtGXkSW2SV4DJQEHdslFUioP0SMccotjwqTdI0b4XH/qZh6CN+kQ=="
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-1.2.0.tgz",
+			"integrity": "sha512-mwhXGkRV5dlvQc4EgPDxDxO6WuMBVymGFd1CA+2Y+z5dG9MNspoQ+AWjl/Ld1MnpCL8AKbosZlDVohqcIwuWsw=="
 		},
 		"@types/babel__core": {
 			"version": "7.1.2",
@@ -1047,9 +1044,9 @@
 			}
 		},
 		"base64-js": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
-			"integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+			"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
 		},
 		"bcrypt-pbkdf": {
 			"version": "1.0.2",
@@ -2658,22 +2655,30 @@
 			"dev": true
 		},
 		"gaxios": {
-			"version": "1.8.4",
-			"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-1.8.4.tgz",
-			"integrity": "sha512-BoENMnu1Gav18HcpV9IleMPZ9exM+AvUjrAOV4Mzs/vfz2Lu/ABv451iEXByKiMPn2M140uul1txXCg83sAENw==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-2.1.0.tgz",
+			"integrity": "sha512-Gtpb5sdQmb82sgVkT2GnS2n+Kx4dlFwbeMYcDlD395aEvsLCSQXJJcHt7oJ2LrGxDEAeiOkK79Zv2A8Pzt6CFg==",
 			"requires": {
 				"abort-controller": "^3.0.0",
 				"extend": "^3.0.2",
-				"https-proxy-agent": "^2.2.1",
+				"https-proxy-agent": "^3.0.0",
+				"is-stream": "^2.0.0",
 				"node-fetch": "^2.3.0"
+			},
+			"dependencies": {
+				"is-stream": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+					"integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
+				}
 			}
 		},
 		"gcp-metadata": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-1.0.0.tgz",
-			"integrity": "sha512-Q6HrgfrCQeEircnNP3rCcEgiDv7eF9+1B+1MMgpE190+/+0mjQR8PxeOaRgxZWmdDAF9EIryHB9g1moPiw1SbQ==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-3.2.0.tgz",
+			"integrity": "sha512-ympv+yQ6k5QuWCuwQqnGEvFGS7MBKdcQdj1i188v3bW9QLFIchTGaBCEZxSQapT0jffdn1vdt8oJhB5VBWQO1Q==",
 			"requires": {
-				"gaxios": "^1.0.2",
+				"gaxios": "^2.0.1",
 				"json-bigint": "^0.3.0"
 			}
 		},
@@ -2734,117 +2739,46 @@
 			"dev": true
 		},
 		"google-auth-library": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-3.1.2.tgz",
-			"integrity": "sha512-cDQMzTotwyWMrg5jRO7q0A4TL/3GWBgO7I7q5xGKNiiFf9SmGY/OJ1YsLMgI2MVHHsEGyrqYnbnmV1AE+Z6DnQ==",
+			"version": "5.5.1",
+			"resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-5.5.1.tgz",
+			"integrity": "sha512-zCtjQccWS/EHYyFdXRbfeSGM/gW+d7uMAcVnvXRnjBXON5ijo6s0nsObP0ifqileIDSbZjTlLtgo+UoN8IFJcg==",
 			"requires": {
+				"arrify": "^2.0.0",
 				"base64-js": "^1.3.0",
 				"fast-text-encoding": "^1.0.0",
-				"gaxios": "^1.2.1",
-				"gcp-metadata": "^1.0.0",
-				"gtoken": "^2.3.2",
-				"https-proxy-agent": "^2.2.1",
+				"gaxios": "^2.1.0",
+				"gcp-metadata": "^3.2.0",
+				"gtoken": "^4.1.0",
 				"jws": "^3.1.5",
-				"lru-cache": "^5.0.0",
-				"semver": "^5.5.0"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "5.7.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
-				}
+				"lru-cache": "^5.0.0"
 			}
 		},
 		"google-gax": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/google-gax/-/google-gax-1.1.5.tgz",
-			"integrity": "sha512-G4D/pgj1DD2gGHDq2If34+gAZhhR59odaBV4yrfnRX8Y1XhTc02Krkbh68IITNHiWOEeY06Gq6l0rPi5fsoRCA==",
+			"version": "1.7.5",
+			"resolved": "https://registry.npmjs.org/google-gax/-/google-gax-1.7.5.tgz",
+			"integrity": "sha512-Tz2DFs8umzDcCBTi2W1cY4vEgAKaYRj70g6Hh/MiiZaJizrly7PgyxsIYUGi7sOpEuAbARQymYKvy5mNi8hEbg==",
 			"requires": {
-				"@grpc/grpc-js": "^0.5.2",
+				"@grpc/grpc-js": "0.6.9",
 				"@grpc/proto-loader": "^0.5.1",
+				"abort-controller": "^3.0.0",
 				"duplexify": "^3.6.0",
-				"google-auth-library": "^4.0.0",
+				"google-auth-library": "^5.0.0",
 				"is-stream-ended": "^0.1.4",
 				"lodash.at": "^4.6.0",
 				"lodash.has": "^4.5.2",
+				"node-fetch": "^2.6.0",
 				"protobufjs": "^6.8.8",
 				"retry-request": "^4.0.0",
 				"semver": "^6.0.0",
 				"walkdir": "^0.4.0"
-			},
-			"dependencies": {
-				"@grpc/grpc-js": {
-					"version": "0.5.2",
-					"resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-0.5.2.tgz",
-					"integrity": "sha512-NE1tP/1AF6BqhLdILElnF7aOBfoky+4ZOdZU/0NmKo2d+9F9QD8zGoElpBk/5BfyQZ3u1Zs+wFbDOFpVUzDx1w==",
-					"requires": {
-						"semver": "^6.0.0"
-					}
-				},
-				"gaxios": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-2.0.1.tgz",
-					"integrity": "sha512-c1NXovTxkgRJTIgB2FrFmOFg4YIV6N/bAa4f/FZ4jIw13Ql9ya/82x69CswvotJhbV3DiGnlTZwoq2NVXk2Irg==",
-					"requires": {
-						"abort-controller": "^3.0.0",
-						"extend": "^3.0.2",
-						"https-proxy-agent": "^2.2.1",
-						"node-fetch": "^2.3.0"
-					}
-				},
-				"gcp-metadata": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-2.0.1.tgz",
-					"integrity": "sha512-nrbLj5O1MurvpLC/doFwzdTfKnmYGDYXlY/v7eQ4tJNVIvQXbOK672J9UFbradbtmuTkyHzjpzD8HD0Djz0LWw==",
-					"requires": {
-						"gaxios": "^2.0.0",
-						"json-bigint": "^0.3.0"
-					}
-				},
-				"google-auth-library": {
-					"version": "4.2.5",
-					"resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-4.2.5.tgz",
-					"integrity": "sha512-Vfsr82M1KTdT0H0wjawwp0LHsT6mPKSolRp21ZpJ7Ydq63zRe8DbGKjRCCrhsRZHg+p17DuuSCMEznwk3CJRdw==",
-					"requires": {
-						"arrify": "^2.0.0",
-						"base64-js": "^1.3.0",
-						"fast-text-encoding": "^1.0.0",
-						"gaxios": "^2.0.0",
-						"gcp-metadata": "^2.0.0",
-						"gtoken": "^3.0.0",
-						"jws": "^3.1.5",
-						"lru-cache": "^5.0.0"
-					}
-				},
-				"google-p12-pem": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-2.0.1.tgz",
-					"integrity": "sha512-6h6x+eBX3k+IDSe/c8dVYmn8Mzr1mUcmKC9MdUSwaBkFAXlqBEnwFWmSFgGC+tcqtsLn73BDP/vUNWEehf1Rww==",
-					"requires": {
-						"node-forge": "^0.8.0"
-					}
-				},
-				"gtoken": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/gtoken/-/gtoken-3.0.2.tgz",
-					"integrity": "sha512-BOBi6Zz31JfxhSHRZBIDdbwIbOPyux10WxJHdx8wz/FMP1zyN1xFrsAWsgcLe5ww5v/OZu/MePUEZAjgJXSauA==",
-					"requires": {
-						"gaxios": "^2.0.0",
-						"google-p12-pem": "^2.0.0",
-						"jws": "^3.1.5",
-						"mime": "^2.2.0"
-					}
-				}
 			}
 		},
 		"google-p12-pem": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-1.0.4.tgz",
-			"integrity": "sha512-SwLAUJqUfTB2iS+wFfSS/G9p7bt4eWcc2LyfvmUXe7cWp6p3mpxDo6LLI29MXdU6wvPcQ/up298X7GMC5ylAlA==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-2.0.2.tgz",
+			"integrity": "sha512-UfnEARfJKI6pbmC1hfFFm+UAcZxeIwTiEcHfqKe/drMsXD/ilnVjF7zgOGpHXyhuvX6jNJK3S8A0hOQjwtFxEw==",
 			"requires": {
-				"node-forge": "^0.8.0",
-				"pify": "^4.0.0"
+				"node-forge": "^0.9.0"
 			}
 		},
 		"graceful-fs": {
@@ -2860,15 +2794,14 @@
 			"dev": true
 		},
 		"gtoken": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/gtoken/-/gtoken-2.3.3.tgz",
-			"integrity": "sha512-EaB49bu/TCoNeQjhCYKI/CurooBKkGxIqFHsWABW0b25fobBYVTMe84A8EBVVZhl8emiUdNypil9huMOTmyAnw==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/gtoken/-/gtoken-4.1.0.tgz",
+			"integrity": "sha512-wqyn2gf5buzEZN4QNmmiiW2i2JkEdZnL7Z/9p44RtZqgt4077m4khRgAYNuu8cBwHWCc6MsP6eDUn/KkF6jFIw==",
 			"requires": {
-				"gaxios": "^1.0.4",
-				"google-p12-pem": "^1.0.0",
+				"gaxios": "^2.0.0",
+				"google-p12-pem": "^2.0.0",
 				"jws": "^3.1.5",
-				"mime": "^2.2.0",
-				"pify": "^4.0.0"
+				"mime": "^2.2.0"
 			}
 		},
 		"handlebars": {
@@ -2985,9 +2918,9 @@
 			}
 		},
 		"https-proxy-agent": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.2.tgz",
-			"integrity": "sha512-c8Ndjc9Bkpfx/vCJueCPy0jlP4ccCCSNDp8xwCZzPjKJUm+B+u9WX2x98Qx4n1PiMNTWo3D7KK5ifNV/yJyRzg==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-3.0.1.tgz",
+			"integrity": "sha512-+ML2Rbh6DAuee7d07tYGEKOEi2voWPUGan+ExdPbPW6Z3svq+JCqr0v8WmKPOkz1vOVykPCBSuobe7G8GJUtVg==",
 			"requires": {
 				"agent-base": "^4.3.0",
 				"debug": "^3.1.0"
@@ -4511,9 +4444,9 @@
 			"integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
 		},
 		"node-forge": {
-			"version": "0.8.5",
-			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.5.tgz",
-			"integrity": "sha512-vFMQIWt+J/7FLNyKouZ9TazT74PRV3wgv9UT4cRjC8BffxFbKXkgIWR42URCPSnHm/QDz6BOlb2Q0U4+VQT67Q=="
+			"version": "0.9.1",
+			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.1.tgz",
+			"integrity": "sha512-G6RlQt5Sb4GMBzXvhfkeFmbqR6MzhtnT7VTHuLadjkii3rdYHNdw0m8zA4BTxVIh68FicCQ2NSUANpsqkr9jvQ=="
 		},
 		"node-int64": {
 			"version": "0.4.0",
@@ -4874,7 +4807,8 @@
 		"pify": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-			"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
+			"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+			"dev": true
 		},
 		"pirates": {
 			"version": "4.0.1",
@@ -5090,9 +5024,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "10.14.12",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.12.tgz",
-					"integrity": "sha512-QcAKpaO6nhHLlxWBvpc4WeLrTvPqlHOvaj0s5GriKkA1zq+bsFBPpfYCvQhLqLgYlIko8A9YrPdaMHCo5mBcpg=="
+					"version": "10.17.0",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.0.tgz",
+					"integrity": "sha512-wuJwN2KV4tIRz1bu9vq5kSPasJ8IsEjZaP1ZR7KlmdUZvGF/rXy8DmXOVwUD0kAtvtJ7aqMKPqUXC0NUTDbrDg=="
 				}
 			}
 		},
@@ -5705,14 +5639,6 @@
 			"integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
 			"dev": true
 		},
-		"split-array-stream": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/split-array-stream/-/split-array-stream-2.0.0.tgz",
-			"integrity": "sha512-hmMswlVY91WvGMxs0k8MRgq8zb2mSen4FmDNc5AFiTWtrBpdZN6nwD6kROVe4vNL+ywrvbCKsWVCnEd4riELIg==",
-			"requires": {
-				"is-stream-ended": "^0.1.4"
-			}
-		},
 		"split-string": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -5777,14 +5703,6 @@
 			"resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
 			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
 			"dev": true
-		},
-		"stream-events": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.5.tgz",
-			"integrity": "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==",
-			"requires": {
-				"stubs": "^3.0.0"
-			}
 		},
 		"stream-shift": {
 			"version": "1.0.0",
@@ -5888,11 +5806,6 @@
 			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
 			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
 			"dev": true
-		},
-		"stubs": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
-			"integrity": "sha1-6NK6H6nJBXAwPAMLaQD31fiavls="
 		},
 		"supports-color": {
 			"version": "5.5.0",
@@ -6253,9 +6166,9 @@
 			}
 		},
 		"walkdir": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.4.0.tgz",
-			"integrity": "sha512-Ps0LSr9doEPbF4kEQi6sk5RgzIGLz9+OroGj1y2osIVnufjNQWSLEGIbZwW5V+j/jK8lCj/+8HSWs+6Q/rnViA=="
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.4.1.tgz",
+			"integrity": "sha512-3eBwRyEln6E1MSzcxcVpQIhRG8Q1jLvEqRmCZqS3dsfXEDR/AhOF4d+jHg1qvDCpYaVRZjENPQyrVxAkQqxPgQ=="
 		},
 		"walker": {
 			"version": "1.0.7",
@@ -6404,9 +6317,9 @@
 			"dev": true
 		},
 		"yallist": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-			"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+			"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
 		},
 		"yargs": {
 			"version": "12.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ecobee/nodejs-gcloud-pubsub-module",
-	"version": "0.0.2",
+	"version": "0.1.0",
 	"description": "A GCloud Pub/Sub module for NestJS",
 	"main": "index.js",
 	"repository": {
@@ -40,7 +40,7 @@
 		"@nestjs/microservices": "^6.5.2"
 	},
 	"dependencies": {
-		"@google-cloud/pubsub": "^0.30.1",
+		"@google-cloud/pubsub": "^1.1.5",
 		"reflect-metadata": "^0.1.12",
 		"rxjs": "^6.0.0"
 	},

--- a/src/helpers/testHelpers.ts
+++ b/src/helpers/testHelpers.ts
@@ -1,6 +1,7 @@
 import { PublishOptions } from '@google-cloud/pubsub/build/src/topic'
 import { GoogleAuthOptions } from '../interfaces/gcloud-pub-sub.interface'
 import { PUB_SUB_DEFAULT_RETRY_CODES, PUB_SUB_DEFAULT_BACKOFF_SETTINGS } from './constants'
+import { SubscriberOptions } from '@google-cloud/pubsub/build/src/subscriber'
 
 export const mockGoogleAuthOptions: GoogleAuthOptions = {
 	projectId: 'entitlement',
@@ -12,5 +13,12 @@ export const mockPublishOptions: PublishOptions = {
 			retryCodes: PUB_SUB_DEFAULT_RETRY_CODES,
 			backoffSettings: PUB_SUB_DEFAULT_BACKOFF_SETTINGS,
 		},
+	},
+}
+
+export const mockSubscriberOptions: SubscriberOptions = {
+	flowControl: {
+		maxMessages: 5,
+		allowExcessMessages: false,
 	},
 }

--- a/src/interfaces/gcloud-pub-sub.interface.ts
+++ b/src/interfaces/gcloud-pub-sub.interface.ts
@@ -1,6 +1,7 @@
 import { Type } from '@nestjs/common'
 import { ModuleMetadata } from '@nestjs/common/interfaces'
 import { PublishOptions } from '@google-cloud/pubsub/build/src/topic'
+import { SubscriberOptions } from '@google-cloud/pubsub/build/src/subscriber'
 
 export interface GCloudPubSubServerOptions {
 	authOptions: GoogleAuthOptions
@@ -34,31 +35,6 @@ export interface GoogleAuthOptions {
 	scopes?: string | string[]
 	projectId?: string
 	uri?: string
-}
-
-export interface SubscriberOptions {
-	ackDeadline?: number
-	flowControl?: FlowControlOptions
-	batching?: BatchOptions
-	streamingOptions?: MessageStreamOptions
-}
-
-export interface MessageStreamOptions {
-	highWaterMark?: number
-	maxStreams?: number
-	timeout?: number
-}
-
-export interface BatchOptions {
-	maxMessages?: number
-	maxMilliseconds?: number
-}
-
-export interface FlowControlOptions {
-	allowExcessMessages?: boolean
-	maxBytes?: number
-	maxExtension?: number
-	maxMessages?: number
 }
 
 export interface GcloudPubSubOptionsFactory {

--- a/src/interfaces/gcloud-pub-sub.interface.ts
+++ b/src/interfaces/gcloud-pub-sub.interface.ts
@@ -5,6 +5,7 @@ import { PublishOptions } from '@google-cloud/pubsub/build/src/topic'
 export interface GCloudPubSubServerOptions {
 	authOptions: GoogleAuthOptions
 	subscriptionIds: string[]
+	subscriberOptions?: SubscriberOptions
 }
 
 export type GcloudPubSubModuleOptions = {
@@ -33,6 +34,31 @@ export interface GoogleAuthOptions {
 	scopes?: string | string[]
 	projectId?: string
 	uri?: string
+}
+
+export interface SubscriberOptions {
+	ackDeadline?: number
+	flowControl?: FlowControlOptions
+	batching?: BatchOptions
+	streamingOptions?: MessageStreamOptions
+}
+
+export interface MessageStreamOptions {
+	highWaterMark?: number
+	maxStreams?: number
+	timeout?: number
+}
+
+export interface BatchOptions {
+	maxMessages?: number
+	maxMilliseconds?: number
+}
+
+export interface FlowControlOptions {
+	allowExcessMessages?: boolean
+	maxBytes?: number
+	maxExtension?: number
+	maxMessages?: number
 }
 
 export interface GcloudPubSubOptionsFactory {

--- a/src/microservice/gcloud-pub-sub.server.ts
+++ b/src/microservice/gcloud-pub-sub.server.ts
@@ -11,7 +11,7 @@ export class GCloudPubSubServer extends Server implements CustomTransportStrateg
 	public subscriptions: Subscription[] = []
 	public isClosing: boolean = false
 
-	constructor(private readonly options: GCloudPubSubServerOptions) {
+	constructor(public readonly options: GCloudPubSubServerOptions) {
 		super()
 	}
 

--- a/src/microservice/gcloud-pub-sub.server.ts
+++ b/src/microservice/gcloud-pub-sub.server.ts
@@ -19,7 +19,10 @@ export class GCloudPubSubServer extends Server implements CustomTransportStrateg
 		this.isClosing = false
 		this.client = new PubSub(this.options.authOptions)
 		this.options.subscriptionIds.forEach(subcriptionName => {
-			const subscription = this.client.subscription(subcriptionName)
+			const subscription = this.client.subscription(
+				subcriptionName,
+				this.options.subscriberOptions || {}
+			)
 			const handleMessage = this.handleMessageFactory(subcriptionName)
 			const handleError = this.handleErrorFactory(subscription)
 			subscription.on(MESSAGE, handleMessage.bind(this))


### PR DESCRIPTION
This PR adds [subscriberOptions](https://googleapis.dev/nodejs/pubsub/latest/global.html#SubscriberOptions) to the GCloudPubSubServerOptions that are passed to the microservice. These options are then applied to all subscriptions.

Additionally there is a version bump to the 1.x.x pubsub library. 