### PR TITLE
HS-1587: Update data type for publishMessage to support buffer / uint8array / etc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ecobee/nodejs-gcloud-pubsub-module",
-	"version": "0.3.0",
+	"version": "0.4.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ecobee/nodejs-gcloud-pubsub-module",
-	"version": "0.3.0",
+	"version": "0.4.0",
 	"description": "A GCloud Pub/Sub module for NestJS",
 	"main": "index.js",
 	"repository": {

--- a/src/module/__snapshots__/gcloud-pub-sub.service.spec.ts.snap
+++ b/src/module/__snapshots__/gcloud-pub-sub.service.spec.ts.snap
@@ -1,6 +1,202 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`GcloudPubSubService publishMessage Publishes a new message 1`] = `
+exports[`GcloudPubSubService publishMessage Publishing a new message handles Buffer as data 1`] = `
+Object {
+  "data": Array [
+    89,
+    111,
+    117,
+    32,
+    84,
+    114,
+    105,
+    101,
+    100,
+    32,
+    89,
+    111,
+    117,
+    114,
+    32,
+    66,
+    101,
+    115,
+    116,
+    32,
+    97,
+    110,
+    100,
+    32,
+    89,
+    111,
+    117,
+    32,
+    70,
+    97,
+    105,
+    108,
+    101,
+    100,
+    32,
+    77,
+    105,
+    115,
+    101,
+    114,
+    97,
+    98,
+    108,
+    121,
+    46,
+    32,
+    84,
+    104,
+    101,
+    32,
+    76,
+    101,
+    115,
+    115,
+    111,
+    110,
+    32,
+    73,
+    115,
+    32,
+    78,
+    101,
+    118,
+    101,
+    114,
+    32,
+    84,
+    114,
+    121,
+  ],
+  "type": "Buffer",
+}
+`;
+
+exports[`GcloudPubSubService publishMessage Publishing a new message handles a SharedArrayBuffer as data 1`] = `
+Object {
+  "data": Array [
+    0,
+  ],
+  "type": "Buffer",
+}
+`;
+
+exports[`GcloudPubSubService publishMessage Publishing a new message handles a Uint8Array as data 1`] = `
+Object {
+  "data": Array [
+    1,
+    2,
+    3,
+  ],
+  "type": "Buffer",
+}
+`;
+
+exports[`GcloudPubSubService publishMessage Publishing a new message handles a string and binary encoding 1`] = `
+Object {
+  "data": Array [
+    89,
+    111,
+    117,
+    32,
+    84,
+    114,
+    105,
+    101,
+    100,
+    32,
+    89,
+    111,
+    117,
+    114,
+    32,
+    66,
+    101,
+    115,
+    116,
+    32,
+    97,
+    110,
+    100,
+    32,
+    89,
+    111,
+    117,
+    32,
+    70,
+    97,
+    105,
+    108,
+    101,
+    100,
+    32,
+    77,
+    105,
+    115,
+    101,
+    114,
+    97,
+    98,
+    108,
+    121,
+    46,
+    32,
+    84,
+    104,
+    101,
+    32,
+    76,
+    101,
+    115,
+    115,
+    111,
+    110,
+    32,
+    73,
+    115,
+    32,
+    78,
+    101,
+    118,
+    101,
+    114,
+    32,
+    84,
+    114,
+    121,
+  ],
+  "type": "Buffer",
+}
+`;
+
+exports[`GcloudPubSubService publishMessage Publishing a new message handles an ArrayBuffer as data 1`] = `
+Object {
+  "data": Array [
+    0,
+  ],
+  "type": "Buffer",
+}
+`;
+
+exports[`GcloudPubSubService publishMessage Publishing a new message handles an array of numbers as data 1`] = `
+Object {
+  "data": Array [
+    10,
+    20,
+    30,
+    40,
+    50,
+  ],
+  "type": "Buffer",
+}
+`;
+
+exports[`GcloudPubSubService publishMessage Publishing a new message handles string as data 1`] = `
 Object {
   "data": Array [
     89,

--- a/src/module/gcloud-pub-sub.service.spec.ts
+++ b/src/module/gcloud-pub-sub.service.spec.ts
@@ -32,18 +32,106 @@ describe('GcloudPubSubService', () => {
 	})
 
 	describe('publishMessage', () => {
-		it('Publishes a new message', async () => {
-			const topic = 'Homer'
-			const data = 'You Tried Your Best and You Failed Miserably. The Lesson Is Never Try'
-			const gcloudPubSubLibMock = {
-				topic: jest.fn().mockReturnThis(),
-				publish: jest.fn(buffer => {
-					expect(buffer).toMatchSnapshot()
-				}),
-			}
-			service.gcloudPubSubLib = gcloudPubSubLibMock as any
-			service.publishMessage(topic, data)
-			expect(gcloudPubSubLibMock.publish).toHaveBeenCalled()
+		describe('Publishing a new message', () => {
+			it('handles string as data', () => {
+				const topic = 'Homer'
+				const data = 'You Tried Your Best and You Failed Miserably. The Lesson Is Never Try'
+				const gcloudPubSubLibMock = {
+					topic: jest.fn().mockReturnThis(),
+					publish: jest.fn(buffer => {
+						expect(buffer).toMatchSnapshot()
+					}),
+				}
+
+				service.gcloudPubSubLib = gcloudPubSubLibMock as any
+				service.publishMessage(topic, data)
+				expect(gcloudPubSubLibMock.publish).toHaveBeenCalled()
+			})
+			it('handles Buffer as data', () => {
+				const topic = 'Homer'
+				const data = 'You Tried Your Best and You Failed Miserably. The Lesson Is Never Try'
+				const gcloudPubSubLibMock = {
+					topic: jest.fn().mockReturnThis(),
+					publish: jest.fn(buffer => {
+						expect(buffer).toMatchSnapshot()
+					}),
+				}
+
+				service.gcloudPubSubLib = gcloudPubSubLibMock as any
+				service.publishMessage(topic, Buffer.from(data))
+				expect(gcloudPubSubLibMock.publish).toHaveBeenCalled()
+			})
+			it('handles an array of numbers as data', () => {
+				const topic = 'Homer'
+				const data = [10, 20, 30, 40, 50]
+				const gcloudPubSubLibMock = {
+					topic: jest.fn().mockReturnThis(),
+					publish: jest.fn(buffer => {
+						expect(buffer).toMatchSnapshot()
+					}),
+				}
+
+				service.gcloudPubSubLib = gcloudPubSubLibMock as any
+				service.publishMessage(topic, data)
+				expect(gcloudPubSubLibMock.publish).toHaveBeenCalled()
+			})
+			it('handles an ArrayBuffer as data', () => {
+				const topic = 'Homer'
+				const data = new ArrayBuffer(1)
+				const gcloudPubSubLibMock = {
+					topic: jest.fn().mockReturnThis(),
+					publish: jest.fn(buffer => {
+						expect(buffer).toMatchSnapshot()
+					}),
+				}
+
+				service.gcloudPubSubLib = gcloudPubSubLibMock as any
+				service.publishMessage(topic, data)
+				expect(gcloudPubSubLibMock.publish).toHaveBeenCalled()
+			})
+			it('handles a SharedArrayBuffer as data', () => {
+				const topic = 'Homer'
+				const data = new SharedArrayBuffer(1)
+				const gcloudPubSubLibMock = {
+					topic: jest.fn().mockReturnThis(),
+					publish: jest.fn(buffer => {
+						expect(buffer).toMatchSnapshot()
+					}),
+				}
+
+				service.gcloudPubSubLib = gcloudPubSubLibMock as any
+				service.publishMessage(topic, data)
+				expect(gcloudPubSubLibMock.publish).toHaveBeenCalled()
+			})
+			it('handles a Uint8Array as data', () => {
+				const topic = 'Homer'
+				const data = new Uint8Array([1, 2, 3])
+				const gcloudPubSubLibMock = {
+					topic: jest.fn().mockReturnThis(),
+					publish: jest.fn(buffer => {
+						expect(buffer).toMatchSnapshot()
+					}),
+				}
+
+				service.gcloudPubSubLib = gcloudPubSubLibMock as any
+				service.publishMessage(topic, data)
+				expect(gcloudPubSubLibMock.publish).toHaveBeenCalled()
+			})
+			it('handles a string and binary encoding', () => {
+				const topic = 'Homer'
+				const data = 'You Tried Your Best and You Failed Miserably. The Lesson Is Never Try'
+				const encoding = 'binary'
+				const gcloudPubSubLibMock = {
+					topic: jest.fn().mockReturnThis(),
+					publish: jest.fn(buffer => {
+						expect(buffer).toMatchSnapshot()
+					}),
+				}
+
+				service.gcloudPubSubLib = gcloudPubSubLibMock as any
+				service.publishMessage(topic, data, {}, encoding)
+				expect(gcloudPubSubLibMock.publish).toHaveBeenCalled()
+			})
 		})
 	})
 })

--- a/src/module/gcloud-pub-sub.service.ts
+++ b/src/module/gcloud-pub-sub.service.ts
@@ -16,10 +16,24 @@ export class GcloudPubSubService {
 
 	public publishMessage(
 		topic: string,
-		data: string,
-		attributes: { [key: string]: string } = {}
+		data: string | Uint8Array | number[] | ArrayBuffer | SharedArrayBuffer,
+		attributes: { [key: string]: string } = {},
+		encoding?: BufferEncoding
 	): Promise<string> {
-		const dataBuffer = Buffer.from(data)
+		let dataBuffer: Buffer = undefined
+		if (typeof data === 'string' && encoding) {
+			dataBuffer = Buffer.from(data as string, encoding)
+		} else if (Array.isArray(data)) {
+			dataBuffer = Buffer.from(data as number[])
+		} else if (data instanceof ArrayBuffer) {
+			dataBuffer = Buffer.from(data as ArrayBuffer)
+		} else if (data instanceof SharedArrayBuffer) {
+			dataBuffer = Buffer.from(data as SharedArrayBuffer)
+		} else if (data instanceof Uint8Array) {
+			dataBuffer = Buffer.from(data as Uint8Array)
+		} else {
+			dataBuffer = Buffer.from(data as string)
+		}
 		return this.gcloudPubSubLib.topic(topic, this.publishOptions).publish(dataBuffer, attributes)
 	}
 }


### PR DESCRIPTION
### Context

`publishMessage` currently only supports data of type `string` as an argument when Buffer.from() is capable of taking in other types:
- `Uint8Array` / `SharedArrayBuffer` / `ArrayBuffer` / `number[]` 

### Changes made

Update `data` type to be those 4 possible types.