### PR TITLE
HS-3218 update to latest client version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ecobee/nodejs-gcloud-pubsub-module",
-	"version": "0.7.1",
+	"version": "0.8.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -229,9 +229,9 @@
 			}
 		},
 		"@google-cloud/paginator": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-3.0.6.tgz",
-			"integrity": "sha512-XCTm/GfQIlc1ZxpNtTSs/mnZxC2cePNhxU3X8EzHXKIJ2JFncmJj2Fcd2IP+gbmZaSZnY0juFxbUCkIeuu/2eQ==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-4.0.0.tgz",
+			"integrity": "sha512-wNmCZl+2G2DmgT/VlF+AROf80SoaC/CwS8trwmjNaq26VRNK8yPbU5F/Vy+R9oDAGKWQU2k8+Op5H4kFJVXFaQ==",
 			"requires": {
 				"arrify": "^2.0.0",
 				"extend": "^3.0.2"
@@ -253,53 +253,53 @@
 			"integrity": "sha512-j8yRSSqswWi1QqUGKVEKOG03Q7qOoZP6/h2zN2YO+F5h2+DHU0bSrHCK9Y7lo2DI9fBd8qGAw795sf+3Jva4yA=="
 		},
 		"@google-cloud/pubsub": {
-			"version": "2.18.1",
-			"resolved": "https://registry.npmjs.org/@google-cloud/pubsub/-/pubsub-2.18.1.tgz",
-			"integrity": "sha512-L2ejjRPszBybsRXJMLHN19UimpchNLNrtE7hJtoZxcy4fhITQGIDk1Ba4LceJYgSMJGA/YatZMYNavgyYpxhvA==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@google-cloud/pubsub/-/pubsub-3.0.1.tgz",
+			"integrity": "sha512-dznNbRd/Y8J0C0xvdvCPi3B1msK/dj/Nya+NQZ2doUOLT6eoa261tBwk9umOQs5L5GKcdlqQKbBjrNjDYVbzQA==",
 			"requires": {
-				"@google-cloud/paginator": "^3.0.0",
+				"@google-cloud/paginator": "^4.0.0",
 				"@google-cloud/precise-date": "^2.0.0",
 				"@google-cloud/projectify": "^2.0.0",
 				"@google-cloud/promisify": "^2.0.0",
 				"@opentelemetry/api": "^1.0.0",
-				"@opentelemetry/semantic-conventions": "^0.24.0",
+				"@opentelemetry/semantic-conventions": "^1.0.0",
 				"@types/duplexify": "^3.6.0",
 				"@types/long": "^4.0.0",
 				"arrify": "^2.0.0",
 				"extend": "^3.0.2",
-				"google-auth-library": "^7.0.0",
-				"google-gax": "^2.24.1",
+				"google-auth-library": "^8.0.2",
+				"google-gax": "^3.0.1",
 				"is-stream-ended": "^0.1.4",
 				"lodash.snakecase": "^4.1.1",
 				"p-defer": "^3.0.0"
 			}
 		},
 		"@grpc/grpc-js": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.4.1.tgz",
-			"integrity": "sha512-/chkA48TdAvATHA7RXJPeHQLdfFhpu51974s8htjO/XTDHA41j5+SkR5Io+lr9XsLmkZD6HxLyRAFGmA9wjO2w==",
+			"version": "1.6.7",
+			"resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.6.7.tgz",
+			"integrity": "sha512-eBM03pu9hd3VqDQG+kHahiG1x80RGkkqqRb1Pchcwqej/KkAH95gAvKs6laqaHCycYaPK+TKuNQnOz9UXYA8qw==",
 			"requires": {
 				"@grpc/proto-loader": "^0.6.4",
 				"@types/node": ">=12.12.47"
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "16.11.4",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.4.tgz",
-					"integrity": "sha512-TMgXmy0v2xWyuCSCJM6NCna2snndD8yvQF67J29ipdzMcsPa9u+o0tjF5+EQNdhcuZplYuouYqpc4zcd5I6amQ=="
+					"version": "18.0.0",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.0.tgz",
+					"integrity": "sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA=="
 				}
 			}
 		},
 		"@grpc/proto-loader": {
-			"version": "0.6.6",
-			"resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.6.6.tgz",
-			"integrity": "sha512-cdMaPZ8AiFz6ua6PUbP+LKbhwJbFXnrQ/mlnKGUyzDUZ3wp7vPLksnmLCBX6SHgSmjX7CbNVNLFYD5GmmjO4GQ==",
+			"version": "0.6.13",
+			"resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.6.13.tgz",
+			"integrity": "sha512-FjxPYDRTn6Ec3V0arm1FtSpmP6V50wuph2yILpyvTKzjc76oDdoihXqM1DzOW5ubvCC8GivfCnNtfaRE8myJ7g==",
 			"requires": {
 				"@types/long": "^4.0.1",
 				"lodash.camelcase": "^4.3.0",
 				"long": "^4.0.0",
-				"protobufjs": "^6.10.0",
-				"yargs": "^16.1.1"
+				"protobufjs": "^6.11.3",
+				"yargs": "^16.2.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -899,19 +899,19 @@
 			}
 		},
 		"@opentelemetry/api": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.0.3.tgz",
-			"integrity": "sha512-puWxACExDe9nxbBB3lOymQFrLYml2dVOrd7USiVRnSbgXE+KwBu+HxFvxrzfqsiSda9IWsXJG1ef7C1O2/GmKQ=="
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.1.0.tgz",
+			"integrity": "sha512-hf+3bwuBwtXsugA2ULBc95qxrOqP2pOekLz34BJhcAKawt94vfeNyUKpYc0lZQ/3sCP6LqRa7UAdHA7i5UODzQ=="
 		},
 		"@opentelemetry/semantic-conventions": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.24.0.tgz",
-			"integrity": "sha512-a/szuMQV0Quy0/M7kKdglcbRSoorleyyOwbTNNJ32O+RBN766wbQlMTvdimImTmwYWGr+NJOni1EcC242WlRcA=="
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.3.1.tgz",
+			"integrity": "sha512-wU5J8rUoo32oSef/rFpOT1HIjLjAv3qIDHkw1QIhODV3OpAVHi5oVzlouozg9obUmZKtbZ0qUe/m7FP0y0yBzA=="
 		},
 		"@protobufjs/aspromise": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-			"integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78="
+			"integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
 		},
 		"@protobufjs/base64": {
 			"version": "1.1.2",
@@ -926,12 +926,12 @@
 		"@protobufjs/eventemitter": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-			"integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A="
+			"integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
 		},
 		"@protobufjs/fetch": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-			"integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
+			"integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
 			"requires": {
 				"@protobufjs/aspromise": "^1.1.1",
 				"@protobufjs/inquire": "^1.1.0"
@@ -940,27 +940,27 @@
 		"@protobufjs/float": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-			"integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E="
+			"integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
 		},
 		"@protobufjs/inquire": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-			"integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik="
+			"integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
 		},
 		"@protobufjs/path": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-			"integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0="
+			"integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
 		},
 		"@protobufjs/pool": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-			"integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q="
+			"integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
 		},
 		"@protobufjs/utf8": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-			"integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
+			"integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
 		},
 		"@types/babel__core": {
 			"version": "7.1.3",
@@ -1013,9 +1013,9 @@
 			}
 		},
 		"@types/duplexify": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/@types/duplexify/-/duplexify-3.6.0.tgz",
-			"integrity": "sha512-5zOA53RUlzN74bvrSGwjudssD9F3a797sDZQkiYpUOxW+WHaXTCPz4/d5Dgi6FKnOqZ2CpaTo0DhgIfsXAOE/A==",
+			"version": "3.6.1",
+			"resolved": "https://registry.npmjs.org/@types/duplexify/-/duplexify-3.6.1.tgz",
+			"integrity": "sha512-n0zoEj/fMdMOvqbHxmqnza/kXyoGgJmEpsXjpP+gEqE1Ye4yNqc7xWipKnUoMpWhMuzJQSfK2gMrwlElly7OGQ==",
 			"requires": {
 				"@types/node": "*"
 			}
@@ -1072,9 +1072,9 @@
 			}
 		},
 		"@types/long": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
-			"integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
+			"integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
 		},
 		"@types/minimatch": {
 			"version": "3.0.3",
@@ -1480,9 +1480,9 @@
 			}
 		},
 		"bignumber.js": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
-			"integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA=="
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.2.tgz",
+			"integrity": "sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw=="
 		},
 		"brace-expansion": {
 			"version": "1.1.11",
@@ -1567,7 +1567,7 @@
 		"buffer-equal-constant-time": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-			"integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+			"integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
 		},
 		"buffer-from": {
 			"version": "1.1.1",
@@ -1872,9 +1872,9 @@
 			}
 		},
 		"debug": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-			"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
 			"requires": {
 				"ms": "2.1.2"
 			}
@@ -2343,9 +2343,9 @@
 			"dev": true
 		},
 		"fast-text-encoding": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.3.tgz",
-			"integrity": "sha512-dtm4QZH9nZtcDt8qJiOH9fcQd1NAgi+K1O2DbE6GG1PPCK/BWfOH3idCTRQ4ImXRUOyopDEgDEnVEE7Y/2Wrig=="
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.4.tgz",
+			"integrity": "sha512-x6lDDm/tBAzX9kmsPcZsNbvDs3Zey3+scsxaZElS8xWLgUMAg/oFLeewfUz0mu1CblHhhsu15jGkraldkFh8KQ=="
 		},
 		"fb-watchman": {
 			"version": "2.0.0",
@@ -2987,15 +2987,15 @@
 			"dev": true
 		},
 		"gaxios": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.3.2.tgz",
-			"integrity": "sha512-T+ap6GM6UZ0c4E6yb1y/hy2UB6hTrqhglp3XfmU9qbLCGRYhLVV5aRPpC4EmoG8N8zOnkYCgoBz+ScvGAARY6Q==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-5.0.0.tgz",
+			"integrity": "sha512-VD/yc5ln6XU8Ch1hyYY6kRMBE0Yc2np3fPyeJeYHhrPs1i8rgnsApPMWyrugkl7LLoSqpOJVBWlQIa87OAvt8Q==",
 			"requires": {
 				"abort-controller": "^3.0.0",
 				"extend": "^3.0.2",
 				"https-proxy-agent": "^5.0.0",
 				"is-stream": "^2.0.0",
-				"node-fetch": "^2.6.1"
+				"node-fetch": "^2.6.7"
 			},
 			"dependencies": {
 				"is-stream": {
@@ -3006,11 +3006,11 @@
 			}
 		},
 		"gcp-metadata": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-4.3.1.tgz",
-			"integrity": "sha512-x850LS5N7V1F3UcV7PoupzGsyD6iVwTVvsh3tbXfkctZnBnjW5yu5z1/3k3SehF7TyoTIe78rJs02GMMy+LF+A==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-5.0.0.tgz",
+			"integrity": "sha512-gfwuX3yA3nNsHSWUL4KG90UulNiq922Ukj3wLTrcnX33BB7PwB1o0ubR8KVvXu9nJH+P5w1j2SQSNNqto+H0DA==",
 			"requires": {
-				"gaxios": "^4.0.0",
+				"gaxios": "^5.0.0",
 				"json-bigint": "^1.0.0"
 			}
 		},
@@ -3070,47 +3070,54 @@
 			"dev": true
 		},
 		"google-auth-library": {
-			"version": "7.10.1",
-			"resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-7.10.1.tgz",
-			"integrity": "sha512-nQxgM1ZopUMcpMnu95kOSzI+9tJl4YDOZJomSTBGlRLpxfBopdwto7WvzoI87HuN0nQqVETgOsHi/C/po1rppA==",
+			"version": "8.0.3",
+			"resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-8.0.3.tgz",
+			"integrity": "sha512-1eC6yaCrPfkv3bwtb3e0AOct7E7xR/uikDyXNo/j8Wd6a1ldRgAey5FmaDGNJnHNDPLtDiENQLYsA69eXOF5sA==",
 			"requires": {
 				"arrify": "^2.0.0",
 				"base64-js": "^1.3.0",
 				"ecdsa-sig-formatter": "^1.0.11",
 				"fast-text-encoding": "^1.0.0",
-				"gaxios": "^4.0.0",
-				"gcp-metadata": "^4.2.0",
-				"gtoken": "^5.0.4",
+				"gaxios": "^5.0.0",
+				"gcp-metadata": "^5.0.0",
+				"gtoken": "^6.0.0",
 				"jws": "^4.0.0",
 				"lru-cache": "^6.0.0"
 			}
 		},
 		"google-gax": {
-			"version": "2.28.0",
-			"resolved": "https://registry.npmjs.org/google-gax/-/google-gax-2.28.0.tgz",
-			"integrity": "sha512-kuqc8a4+CTCMBcF3tlOL7Sa74JWkTzcZxatAQTCVK35WToXkHnJ0qncFOJuegUv3EbV9IQY4j/+NZdFLv+lbTA==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/google-gax/-/google-gax-3.1.2.tgz",
+			"integrity": "sha512-Knp/tG/GEwTMasIWxtZCbkSK8P8mLPK/utDpeDWYOO60XClMjtSPl6IqJRlKWQvhUhjqmyXH4/LTCs9D2kTGLQ==",
 			"requires": {
-				"@grpc/grpc-js": "~1.4.0",
-				"@grpc/proto-loader": "^0.6.1",
+				"@grpc/grpc-js": "~1.6.0",
+				"@grpc/proto-loader": "^0.6.12",
 				"@types/long": "^4.0.0",
 				"abort-controller": "^3.0.0",
 				"duplexify": "^4.0.0",
 				"fast-text-encoding": "^1.0.3",
-				"google-auth-library": "^7.6.1",
+				"google-auth-library": "^8.0.2",
 				"is-stream-ended": "^0.1.4",
 				"node-fetch": "^2.6.1",
-				"object-hash": "^2.1.1",
-				"proto3-json-serializer": "^0.1.1",
-				"protobufjs": "6.11.2",
-				"retry-request": "^4.0.0"
+				"object-hash": "^3.0.0",
+				"proto3-json-serializer": "^1.0.0",
+				"protobufjs": "6.11.3",
+				"retry-request": "^5.0.0"
+			},
+			"dependencies": {
+				"object-hash": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+					"integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw=="
+				}
 			}
 		},
 		"google-p12-pem": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-3.1.2.tgz",
-			"integrity": "sha512-tjf3IQIt7tWCDsa0ofDQ1qqSCNzahXDxdAGJDbruWqu3eCg5CKLYKN+hi0s6lfvzYZ1GDVr+oDF9OOWlDSdf0A==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-4.0.0.tgz",
+			"integrity": "sha512-lRTMn5ElBdDixv4a86bixejPSRk1boRtUowNepeKEVvYiFlkLuAJUVpEz6PfObDHYEKnZWq/9a2zC98xu62A9w==",
 			"requires": {
-				"node-forge": "^0.10.0"
+				"node-forge": "^1.3.1"
 			}
 		},
 		"graceful-fs": {
@@ -3126,13 +3133,32 @@
 			"dev": true
 		},
 		"gtoken": {
-			"version": "5.3.1",
-			"resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.3.1.tgz",
-			"integrity": "sha512-yqOREjzLHcbzz1UrQoxhBtpk8KjrVhuqPE7od1K2uhyxG2BHjKZetlbLw/SPZak/QqTIQW+addS+EcjqQsZbwQ==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/gtoken/-/gtoken-6.0.1.tgz",
+			"integrity": "sha512-J0vebk6u6i4rLTM0lQq25SdusCLMvujYNZeAouyPvSbGlcjw7P8L3W9INIFnlXUx+AUD7TDoM1mgdhzH+XX7DQ==",
 			"requires": {
 				"gaxios": "^4.0.0",
-				"google-p12-pem": "^3.0.3",
+				"google-p12-pem": "^4.0.0",
 				"jws": "^4.0.0"
+			},
+			"dependencies": {
+				"gaxios": {
+					"version": "4.3.3",
+					"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.3.3.tgz",
+					"integrity": "sha512-gSaYYIO1Y3wUtdfHmjDUZ8LWaxJQpiavzbF5Kq53akSzvmVg0RfyOcFDbO1KJ/KCGRFz2qG+lS81F0nkr7cRJA==",
+					"requires": {
+						"abort-controller": "^3.0.0",
+						"extend": "^3.0.2",
+						"https-proxy-agent": "^5.0.0",
+						"is-stream": "^2.0.0",
+						"node-fetch": "^2.6.7"
+					}
+				},
+				"is-stream": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+					"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="
+				}
 			}
 		},
 		"handlebars": {
@@ -3249,9 +3275,9 @@
 			}
 		},
 		"https-proxy-agent": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-			"integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+			"integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
 			"requires": {
 				"agent-base": "6",
 				"debug": "4"
@@ -5101,7 +5127,7 @@
 		"lodash.camelcase": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-			"integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
+			"integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
 		},
 		"lodash.memoize": {
 			"version": "4.1.2",
@@ -5112,7 +5138,7 @@
 		"lodash.snakecase": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
-			"integrity": "sha1-OdcUo1NXFHg3rv1ktdy7Fr7Nj40="
+			"integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw=="
 		},
 		"lodash.sortby": {
 			"version": "4.7.0",
@@ -5367,9 +5393,9 @@
 			"dev": true
 		},
 		"node-fetch": {
-			"version": "2.6.5",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.5.tgz",
-			"integrity": "sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==",
+			"version": "2.6.7",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+			"integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
 			"requires": {
 				"whatwg-url": "^5.0.0"
 			},
@@ -5377,17 +5403,17 @@
 				"tr46": {
 					"version": "0.0.3",
 					"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-					"integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+					"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
 				},
 				"webidl-conversions": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-					"integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+					"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
 				},
 				"whatwg-url": {
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-					"integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+					"integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
 					"requires": {
 						"tr46": "~0.0.3",
 						"webidl-conversions": "^3.0.0"
@@ -5396,9 +5422,9 @@
 			}
 		},
 		"node-forge": {
-			"version": "0.10.0",
-			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
-			"integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+			"integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA=="
 		},
 		"node-int64": {
 			"version": "0.4.0",
@@ -5523,7 +5549,8 @@
 		"object-hash": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
-			"integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw=="
+			"integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
+			"dev": true
 		},
 		"object-inspect": {
 			"version": "1.7.0",
@@ -5923,14 +5950,17 @@
 			}
 		},
 		"proto3-json-serializer": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-0.1.4.tgz",
-			"integrity": "sha512-bFzdsKU/zaTobWrRxRniMZIzzcgKYlmBWL1gAcTXZ2M7TQTGPI0JoYYs6bN7tpWj59ZCfwg7Ii/A2e8BbQGYnQ=="
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-1.0.2.tgz",
+			"integrity": "sha512-wHxf8jYZ/LUP3M7XmULDKnbxBn+Bvk6SM+tDCPVTp9vraIzUi9hHsOBb1n2Y0VV0ukx4zBN/2vzMQYs4KWwRpg==",
+			"requires": {
+				"protobufjs": "^6.11.3"
+			}
 		},
 		"protobufjs": {
-			"version": "6.11.2",
-			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.2.tgz",
-			"integrity": "sha512-4BQJoPooKJl2G9j3XftkIXjoC9C0Av2NOrWmbLWT1vH32GcSUHjM0Arra6UfTsVyfMAuFzaLucXn1sadxJydAw==",
+			"version": "6.11.3",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
+			"integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
 			"requires": {
 				"@protobufjs/aspromise": "^1.1.2",
 				"@protobufjs/base64": "^1.1.2",
@@ -5948,9 +5978,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "16.11.4",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.4.tgz",
-					"integrity": "sha512-TMgXmy0v2xWyuCSCJM6NCna2snndD8yvQF67J29ipdzMcsPa9u+o0tjF5+EQNdhcuZplYuouYqpc4zcd5I6amQ=="
+					"version": "18.0.0",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.0.tgz",
+					"integrity": "sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA=="
 				}
 			}
 		},
@@ -6181,9 +6211,9 @@
 			"dev": true
 		},
 		"retry-request": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/retry-request/-/retry-request-4.2.2.tgz",
-			"integrity": "sha512-xA93uxUD/rogV7BV59agW/JHPGXeREMWiZc9jhcwY4YdZ7QOtC7qbomYg0n4wyk2lJhggjvKvhNX8wln/Aldhg==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/retry-request/-/retry-request-5.0.1.tgz",
+			"integrity": "sha512-lxFKrlBt0OZzCWh/V0uPEN0vlr3OhdeXnpeY5OES+ckslm791Cb1D5P7lJUSnY7J5hiCjcyaUGmzCnIGDCUBig==",
 			"requires": {
 				"debug": "^4.1.1",
 				"extend": "^3.0.2"
@@ -6996,7 +7026,7 @@
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
 		},
 		"util.promisify": {
 			"version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ecobee/nodejs-gcloud-pubsub-module",
-	"version": "0.7.1",
+	"version": "0.8.0",
 	"description": "A GCloud Pub/Sub module for NestJS",
 	"main": "index.js",
 	"repository": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 		"@nestjs/microservices": "^7.4.0 || ^8.1.2"
 	},
 	"dependencies": {
-		"@google-cloud/pubsub": "^2.18.1",
+		"@google-cloud/pubsub": "^3.0.1",
 		"reflect-metadata": "0.1.12",
 		"rxjs": "^7.4.0"
 	},


### PR DESCRIPTION
In this PR we are updating `@google-cloud/pubsub` to its latest version, 3.0.1.

Bumping version to 0.8.0 to indicate a breaking change. According to the changelog there is one breaking change in the move to v3: https://github.com/googleapis/nodejs-pubsub/blob/main/CHANGELOG.md